### PR TITLE
Better requirements.txt parsing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,14 @@ import sys
 
 import chump
 
+from pip.req import parse_requirements
+
 
 try:
 	from setuptools import setup
 
 except ImportError:
 	from distutils.core import setup
-
-install_requires = []
-for line in open('requirements.txt', 'rU').readlines():
-	if line and line not in '\n' and not line.startswith(('#', '-')):
-		install_requires.append(line.replace('\n', ''))
 
 kwargs = {}
 if sys.version_info >= (3,):
@@ -33,7 +30,7 @@ setup(
 	package_dir={'chump': 'chump'},
 	package_data={'': ['README.rst', 'HISTORY.rst', 'LICENSE']},
 	include_package_data=True,
-	install_requires=install_requires,
+	install_requires=[str(r.req) for r in parse_requirements('requirements.txt')],
 	zip_safe=False,
 	classifiers=(
 		'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Rather than parsing `requirements.txt` ourselves, it's better to let tools that are made for this purpose handle this task. This ensures it won't break in the future, for example on inline comments like `somerequirement==0.0.0  # Some comment here`.
