### PR TITLE
Include docs in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst HISTORY.rst LICENSE
+recursive-include docs *


### PR DESCRIPTION
That would be really nice as Gentoo builds docs from PyPI tarballs and these currently don't include the docs folder.