### PR TITLE
Relicense as MIT.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-Copyright 2013 Karan Lyons
+MIT License
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Copyright (c) 2013 Karan Lyons
 
-	http://www.apache.org/licenses/LICENSE-2.0
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Chump
 	:target: https://chump.readthedocs.org/en/latest/
 	:alt: Documentation Status
 
-Chump is an Apache2 Licensed, fully featured API wrapper for
+Chump is an MIT Licensed, fully featured API wrapper for
 `Pushover <https://pushover.net>`_:
 
 .. code-block:: pycon

--- a/chump/__init__.py
+++ b/chump/__init__.py
@@ -35,7 +35,7 @@ __version__ = '.'.join((unicode(i) for i in VERSION))
 __author__ = 'Karan Lyons'
 __contact__ = 'karan@karanlyons.com'
 __homepage__ = 'https://github.com/karanlyons/chump'
-__license__ = 'Apache 2.0'
+__license__ = 'MIT License'
 __copyright__ = 'Copyright 2013 Karan Lyons'
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Chump
 	:target: https://pypi.python.org/pypi/chump
 	:alt: PyPI Version
 
-Chump is an Apache2 Licensed, fully featured API wrapper for
+Chump is an MIT Licensed, fully featured API wrapper for
 `Pushover <https://pushover.net>`_:
 
 .. code-block:: pycon

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
 		'Development Status :: 5 - Production/Stable',
 		'Intended Audience :: Developers',
 		'Natural Language :: English',
-		'License :: OSI Approved :: Apache Software License',
+		'License :: OSI Approved :: MIT License',
 		'Programming Language :: Python',
 		'Programming Language :: Python :: 2.7',
 		'Programming Language :: Python :: 3',


### PR DESCRIPTION
This’ll have to wait for a major version, but some other changes in the pipeline will need that, too.